### PR TITLE
Refuted: Immigration negatively impacts low skilled workers

### DIFF
--- a/hypotheses/immigration-negatively-impacts-low-skilled-workers.yml
+++ b/hypotheses/immigration-negatively-impacts-low-skilled-workers.yml
@@ -13,7 +13,8 @@ cited_urls:
     over- turns the prior finding that the Mariel boatlift did not affect Miami’s
     wage structure. The wage of high school dropouts in Miami dropped dramatically,
     by 10 to 30%
-refuted_by_hypotheses: []
+refuted_by_hypotheses:
+- immigration-has-very-little-impact-on-wages-for-domestic-workers
 topics:
 - economics
 - immigration


### PR DESCRIPTION
Refute [Immigration negatively impacts low skilled workers](https://www.convus.org/hypotheses/2267)


With _[Immigration has very little impact on wages for domestic workers](https://www.convus.org/hypotheses/immigration-has-very-little-impact-on-wages-for-domestic-workers)_

Because:

1. The citation, _The Wage Impact of the Marielitos: a Reappraisal_ is refuted by:
>  Using a sample of non-Cuban high-school dropouts we find no significant difference in the wages of workers in Miami relative to its control after 1980.

2. Other studies of similar high-immigration periods and places similarly suggest there isn't a negative impact for low skilled workers
> Using longitudinal data on the universe of workers in Denmark during the period 1991-2008, we track the labor market outcomes of low-skilled natives in response to an exogenous inflow of low- skilled immigrants... immigration had positive effects on native unskilled wages, employment, and occupational mobility.



